### PR TITLE
Fixing death camera not showing when dead

### DIFF
--- a/Game Files/Final Project/Assets/Prefabs/ImportantObjects/Submarine/Submarine_NEW.prefab
+++ b/Game Files/Final Project/Assets/Prefabs/ImportantObjects/Submarine/Submarine_NEW.prefab
@@ -846,7 +846,7 @@ Camera:
     serializedVersion: 2
     m_Bits: 4294967295
   m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
+  m_TargetTexture: {fileID: 8400000, guid: a4ad9499a3faa7c4d84a6d332e2d21e1, type: 2}
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0


### PR DESCRIPTION
Change log:
(General description of changes made)

- Fixing a bug

Bugs fixed:
(Specific bugs fixed)

- Fixed Death Camera not showing when player dies

Modified Scripts:
(Specific scripts intended to be modified)

- Submarine_NEW.prefab